### PR TITLE
Replaces: allow SeeAlso & Ptr

### DIFF
--- a/src/sanakirju_simpilifier/replaces.py
+++ b/src/sanakirju_simpilifier/replaces.py
@@ -4,15 +4,11 @@ from .types import File, Files
 regex_replaces = [
     "<RangeOfApplication[^>]*>",
     "<Fragment[^>]*>",
-    "<SeeAlso[^>]*>",
-    "<Ptr[^>]*>",
 ]
 
 replaces = [
     "</RangeOfApplication>",
     "</Fragment>",
-    "</SeeAlso>",
-    "</Ptr>",
 ]
 
 

--- a/tests/test_replaces.py
+++ b/tests/test_replaces.py
@@ -9,15 +9,11 @@ def test_replaces_simple_content_in_xml_files() -> None:
     for _, contents in original_files:
         assert "</RangeOfApplication>" in contents
         assert "</Fragment>" in contents
-        assert "</SeeAlso>" in contents
-        assert "</Ptr>" in contents
 
     # Result should not contain replacable bits.
     for _, contents in results:
         assert "</RangeOfApplication>" not in contents
         assert "</Fragment>" not in contents
-        assert "</SeeAlso>" not in contents
-        assert "</Ptr>" not in contents
 
 
 def test_replaces_regex_content_in_xml_files() -> None:
@@ -28,12 +24,8 @@ def test_replaces_regex_content_in_xml_files() -> None:
     for _, contents in original_files:
         assert "<RangeOfApplication" in contents
         assert "<Fragment" in contents
-        assert "<SeeAlso" in contents
-        assert "<Ptr" in contents
 
     # Result should not contain regexable bits.
     for _, contents in results:
         assert "<RangeOfApplication" not in contents
         assert "<Fragment" not in contents
-        assert "<SeeAlso" not in contents
-        assert "<Ptr" not in contents


### PR DESCRIPTION
They seem to often contain info about word root, which actually is relevant. Sanakirju seems to parse it ok enough, so lets keep them.